### PR TITLE
refactor code to use base class implementation

### DIFF
--- a/code/ModuleRequirements_Backend.php
+++ b/code/ModuleRequirements_Backend.php
@@ -4,34 +4,12 @@ class ModuleRequirements_Backend extends Requirements_Backend {
 	
 	protected function path_for_file($fileOrUrl) {
 		if(preg_match('{^//|http[s]?}', $fileOrUrl)) {
-			return $fileOrUrl;
-			
+			return $fileOrUrl;	
 		} else {
 			if(!Director::fileExists($fileOrUrl)) {
 				$fileOrUrl = MODULES_DIR . '/' . $fileOrUrl;
 			}
-			if(Director::fileExists($fileOrUrl)) {
-				$filePath = preg_replace('/\?.*/', '', Director::baseFolder() . '/' . $fileOrUrl);
-				$prefix = Director::baseURL();
-				$mtimesuffix = "";
-				$suffix = '';
-				if($this->suffix_requirements) {
-					$mtimesuffix = "?m=" . filemtime($filePath);
-					$suffix = '&';
-				}
-				if(strpos($fileOrUrl, '?') !== false) {
-					if (strlen($suffix) == 0) {
-						$suffix = '?';
-					}
-					$suffix .= substr($fileOrUrl, strpos($fileOrUrl, '?')+1);
-					$fileOrUrl = substr($fileOrUrl, 0, strpos($fileOrUrl, '?'));
-				} else {
-					$suffix = '';
-				}
-				return "{$prefix}{$fileOrUrl}{$mtimesuffix}{$suffix}";
-			} else {
-				return false;
-			}
+			return parent::path_for_file($fileOrUrl);
 		}
 	}
 }


### PR DESCRIPTION
We really like the idea of a separate modules directory, thanks for showing the way. Based on your code, I would suggest the following code change in order to keep the required code short and to simplify maintenance. The only downside is an additional preg_match (as the same check is performed in Requirements_Backend#path_for_file).
